### PR TITLE
Update to 3.2.14

### DIFF
--- a/rpm/0001-disabled-gtk-doc.patch
+++ b/rpm/0001-disabled-gtk-doc.patch
@@ -9,7 +9,7 @@ Subject: [PATCH] disabled gtk-doc
  2 files changed, 12 insertions(+), 8 deletions(-)
 
 diff --git a/autogen.sh b/autogen.sh
-index 569e6224..826c2fda 100755
+index 4d4a8b8b..a2f16071 100755
 --- a/autogen.sh
 +++ b/autogen.sh
 @@ -41,12 +41,15 @@ if $have_libtool ; then : ; else
@@ -32,19 +32,19 @@ index 569e6224..826c2fda 100755
  
  (autoconf --version) < /dev/null > /dev/null 2>&1 || {
 @@ -94,7 +97,7 @@ touch ChangeLog
- $ACLOCAL -I m4/ $ACLOCAL_FLAGS || exit $?
+ ${ACLOCAL} -I m4/ ${ACLOCAL_FLAGS} || exit $?
  
- $LIBTOOLIZE --force || exit $?
+ ${LIBTOOLIZE} --force || exit $?
 -gtkdocize || exit $?
 +$gtkdocize
  
  autoheader || exit $?
  
 diff --git a/configure.ac b/configure.ac
-index 857f4f28..622cafbc 100644
+index c6c60296..f2cdad40 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -193,16 +193,17 @@ AC_CHECK_FUNCS(select poll)
+@@ -187,16 +187,17 @@ AC_CHECK_FUNCS(select poll)
  dnl ************************************
  dnl Checks for gtk-doc and docbook-tools
  dnl ************************************
@@ -57,7 +57,7 @@ index 857f4f28..622cafbc 100644
 +])
  
  AC_PATH_PROGS([DB2HTML], [db2html docbook2html])
- AM_CONDITIONAL(HAVE_DOCBOOK, [test -n "$DB2HTML"])
+ AM_CONDITIONAL(HAVE_DOCBOOK, [test -n "$DB2HTML"], "true", "false")
  
 -dnl NOTE: We need to use a separate automake conditional for this
 -dnl       to make this work with the tarballs.
@@ -65,7 +65,4 @@ index 857f4f28..622cafbc 100644
 -
  dnl Check for profiling options
  AC_ARG_ENABLE([profiling],
-               AC_HELP_STRING([--enable-profiling],
--- 
-2.31.1
-
+               AS_HELP_STRING([--enable-profiling],[enable profiling compile flags [[default=no]]]),,

--- a/rpm/0002-Check-ac_cv_sys_file_offset_bits-against-empty-strin.patch
+++ b/rpm/0002-Check-ac_cv_sys_file_offset_bits-against-empty-strin.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jeffrey Stedfast <jestedfa@microsoft.com>
+Date: Sat, 11 May 2024 11:43:36 -0400
+Subject: [PATCH] Check ac_cv_sys_file_offset_bits against empty string
+
+May fix issue #158
+---
+ configure.ac | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index f2cdad40..20994707 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -154,6 +154,7 @@ AC_CHECK_HEADERS(sys/param.h)
+ AC_CHECK_HEADERS(winsock2.h)
+ AC_CHECK_HEADERS(string.h)
+ AC_CHECK_HEADERS(stdlib.h)
++AC_CHECK_HEADERS(stdint.h)
+ AC_CHECK_HEADERS(netdb.h)
+ AC_CHECK_HEADERS(time.h)
+ AC_CHECK_HEADERS(poll.h)
+@@ -432,7 +433,7 @@ if test "x$enable_largefile" != "xno"; then
+         enable_largefile="yes"
+     fi
+     
+-    if test "x$ac_cv_sys_file_offset_bits" != "xno"; then
++    if test "x$ac_cv_sys_file_offset_bits" != "x"; then
+         LFS_CFLAGS="$LFS_CFLAGS -D_FILE_OFFSET_BITS=$ac_cv_sys_file_offset_bits"
+         enable_largefile="yes"
+     fi

--- a/rpm/gmime.spec
+++ b/rpm/gmime.spec
@@ -1,11 +1,12 @@
 Name:       gmime
 Summary:    Library for creating and parsing MIME messages
-Version:    3.2.8
+Version:    3.2.14
 Release:    1
 License:    LGPLv2
 URL:        https://gitlab.gnome.org/GNOME/gmime
 Source0:    gmime-%{version}.tar.xz
 Patch1:     0001-disabled-gtk-doc.patch
+Patch2:     0002-Check-ac_cv_sys_file_offset_bits-against-empty-strin.patch
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
 BuildRequires:  pkgconfig(glib-2.0) >= 2.12.0
@@ -54,12 +55,10 @@ find %{buildroot} -name \*.a -delete
 %postun -p /sbin/ldconfig
 
 %files
-%defattr(-,root,root,-)
 %license COPYING
 %{_libdir}/lib*.so.*
 
 %files devel
-%defattr(-,root,root,-)
 %doc AUTHORS
 %{_libdir}/lib*.so
 %{_libdir}/pkgconfig/gmime-*.pc


### PR DESCRIPTION
Backport upstream patch to fix build with autoconf 2.72. Remove not needed defattr.